### PR TITLE
Error message "the options [property] is not supported"

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = function (uri, opts) {
 
 	opts = opts || {};
 	var property = opts.property || 'db';
+	delete opts.property;
 
 	var connection;
 


### PR DESCRIPTION
When using the `property` option, the following error message appears in the console:

> the options [property] is not supported

That's because the `opts` object is passed directly to `MongoClient.connect` and the `property` is unknown to `MongoClient.connect`. The error message can be prevented by removing `property` from `opts` before passing it to `MongoClient.connect`.