### PR TITLE
[Work In Progress]: Update to 3.0.2 MongoDB Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install --save express-mongo-db
 var app = require('express')();
 
 var expressMongoDb = require('express-mongo-db');
-app.use(expressMongoDb('mongodb://localhost/test'));
+app.use(expressMongoDb('mongodb://localhost/', 'test'));
 
 app.get('/', function (req, res, next) {
 	req.db // => Db object
@@ -26,7 +26,7 @@ app.get('/', function (req, res, next) {
 
 ## API
 
-### expressMongoDb(uri, [options])
+### expressMongoDb(uri, databaseName, [options])
 
 #### uri
 
@@ -35,9 +35,16 @@ Type: `string`
 
 [Connection string uri](http://docs.mongodb.org/manual/reference/connection-string/).
 
+#### databaseName
+
+*Required*  
+Type: `string`
+
+Name of database to connect to.
+
 #### options
 
-All options from [MongoClient](http://mongodb.github.io/node-mongodb-native/2.0/api/MongoClient.html) are accepted as well.
+All options from [MongoClient](http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html) are accepted as well.
 
 ##### property
 

--- a/index.js
+++ b/index.js
@@ -2,9 +2,13 @@
 
 var MongoClient = require('mongodb').MongoClient;
 
-module.exports = function (uri, opts) {
+module.exports = function (uri, databaseName, opts) {
 	if (typeof uri !== 'string') {
 		throw new TypeError('Expected uri to be a string');
+	}
+
+	if (typeof databaseName !== 'string') {
+		throw new TypeError('Expected databaseName to be a string');
 	}
 
 	opts = opts || {};
@@ -19,8 +23,8 @@ module.exports = function (uri, opts) {
 		}
 
 		connection
-			.then(function (db) {
-				req[property] = db;
+			.then(function (client) {
+				req[property] = client.db(databaseName);
 				next();
 			})
 			.catch(function (err) {

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function (uri, databaseName, opts) {
 		connection
 			.then(function (client) {
 				req[property] = client.db(databaseName);
+				req.client = client
 				next();
 			})
 			.catch(function (err) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "express"
   ],
   "dependencies": {
-    "mongodb": "^2.0.39"
+    "body-parser": "^1.18.2",
+    "mongodb": "^3.0.2"
   },
   "devDependencies": {
     "eslint": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "express"
   ],
   "dependencies": {
-    "body-parser": "^1.18.2",
     "mongodb": "^3.0.2"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ test('throws on invalid uri', function (t) {
 });
 
 test('middleware pass error on fail', function (t) {
-	var middleware = expressMongoDb('mongodb://localhost:31337');
+	var middleware = expressMongoDb('mongodb://localhost:31337', 'test');
 
 	middleware({}, {}, function (err) {
 		t.ok(err);
@@ -24,18 +24,18 @@ test('middleware pass error on fail', function (t) {
 });
 
 test('middleware stores connection to mongodb', function (t) {
-	var middleware = expressMongoDb('mongodb://localhost:27017');
+	var middleware = expressMongoDb('mongodb://localhost:27017', 'test');
 	var req = {};
 
 	middleware(req, {}, function (err) {
 		t.error(err);
 		t.ok(req.db);
-		req.db.close(true, t.end);
+		req.client.close(true, t.end);
 	});
 });
 
 test('middleware stores connection in custom property', function (t) {
-	var middleware = expressMongoDb('mongodb://localhost:27017', {
+	var middleware = expressMongoDb('mongodb://localhost:27017', 'test', {
 		property: 'myDb'
 	});
 	var req = {};
@@ -43,12 +43,12 @@ test('middleware stores connection in custom property', function (t) {
 	middleware(req, {}, function (err) {
 		t.error(err);
 		t.ok(req.myDb);
-		req.myDb.close(true, t.end);
+		req.client.close(true, t.end);
 	});
 });
 
 test('returns same connection for multiple requests', function (t) {
-	var middleware = expressMongoDb('mongodb://localhost:27017', {
+	var middleware = expressMongoDb('mongodb://localhost:27017', 'test', {
 		property: 'myDb'
 	});
 	var req = {};
@@ -63,7 +63,7 @@ test('returns same connection for multiple requests', function (t) {
 		middleware(req, {}, function (err) {
 			t.error(err);
 			t.equal(_db, req.myDb);
-			req.myDb.close(true, t.end);
+			req.client.close(true, t.end);
 		});
 	});
 });


### PR DESCRIPTION
## Breaking Change
There was a breaking change in MongoDB 3.0.0

> MongoClient.connect works as expected but it returns the MongoClient instance instead of a database object.
> [Changes in 3.0.0](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CHANGES_3.0.0.md) 


## What this PR Does
This PR adds database name as an additional parameter and adds this database to the req object.

## Performance
I believe that using the [db method](http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#db) this way is not a performace issue because these instances will be cached.

> Child db instances are cached so performing db('db1') twice will return the same instance.
You can control these behaviors with the options noListener and returnNonCachedInstance.

## Alternatives 
It would be possible to rewrite this to make database name optional and return either a client object or a database object depending on if database name is provided. Not sure how common users will want to connect to multiple databases so for now avoided the extra code complexity.

## Issues
I've encountered an issue with updating the tests, they timeout and I'm not sure what is still running that's stopping the process from ending.

```
const MongoClient = require('mongodb').MongoClient;
const connection = MongoClient.connect("badconnectionstring");
```

I'm not familiar with tap so not sure how to proceed with with.



